### PR TITLE
fixed frame_ids not matched bug

### DIFF
--- a/recognition/scripts/face_detection_node.py
+++ b/recognition/scripts/face_detection_node.py
@@ -105,7 +105,7 @@ class FaceDetectionNode:
 	# callback
 	def callback(self, rgb_image_msg, rgb_info_msg, detection_msg):
 	
-		if detection_msg.header.frame_id != self.sensor_name + '_ir_optical_frame':
+		if "/" + detection_msg.header.frame_id != self.sensor_name + '_ir_optical_frame':
 			print 'frame_ids not matched'
 			return
 


### PR DESCRIPTION
Hey,
I found a bug in the face detection, where the sensorname was e.g. "/kinect02"

and the compare did compare the frame_id --> which was kinect02 without the slash

so I added a slash for the compare