### PR TITLE
In Dockerfile catkin_make, use CMAKE_BUILD_TYPE=Release

### DIFF
--- a/docker/open_ptrack/Dockerfile
+++ b/docker/open_ptrack/Dockerfile
@@ -42,7 +42,7 @@ RUN /bin/bash -c "source /opt/ros/melodic/setup.bash \
 RUN /bin/bash -c "source /opt/ros/melodic/setup.bash \
     && cd ~/workspace/ros \
     && export LD_LIBRARY_PATH=/root/workspace/ros/devel/lib:/opt/ros/melodic/lib:/opt/ros/melodic/lib/x86_64-linux-gnu:/usr/local/lib/x86_64-linux-gnu:/usr/local/lib/i386-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu:/usr/local/cuda/lib64 \
-    && catkin_make"
+    && catkin_make -DCMAKE_BUILD_TYPE=Release"
 
 RUN /bin/bash -c "source /root/workspace/ros/devel/setup.bash \
     && roscd yolo_detector/darknet_opt \


### PR DESCRIPTION
Some ROS help pages suggest using the CMAKE_BUILD_TYPE=Release flag for catkin_make. It builds some drivers and they run more efficiently in Release vs Debug. This was mainly recommended for Kinect Azure, but could help other drivers.